### PR TITLE
Put radio-inline directly on label

### DIFF
--- a/struts2-bootstrap-plugin/src/main/resources/template/bootstrap/simple/radiomap.ftl
+++ b/struts2-bootstrap-plugin/src/main/resources/template/bootstrap/simple/radiomap.ftl
@@ -33,11 +33,11 @@
         <#assign itemValue = stack.findString('top')/>
     </#if>
     <#if parameters.labelposition?default("") == 'inline'>
-    <div class="radio-inline">
+        <#assign labelClass="radio-inline"/>
     <#else>
-    <div class="radio">
+        <#assign labelClass="radio"/>
     </#if>
-    <label for="${parameters.name?html}-${itemCount}" class="radio">
+    <label for="${parameters.name?html}-${itemCount}" class="${labelClass}">
         <input type="radio"<#rt/>
             <#if parameters.name??>
                name="${parameters.name?html}"<#rt/>
@@ -70,5 +70,4 @@
                 /><#rt/>
     ${itemValue}<#t/>
     </label>
-</div>
 </@s.iterator>


### PR DESCRIPTION
Bootstrap css expects radio-inline to be on the label.  

For example, without this change, the labels end up with font-weight:700 instead of font-weight:400 
(set by the radio-inline class)