### PR TITLE
fixed issues with FieldError being displayed twice  + cssClass and cssStyle attributes being rendered incorrectly

### DIFF
--- a/struts2-bootstrap-plugin/src/main/resources/template/bootstrap/checkbox.ftl
+++ b/struts2-bootstrap-plugin/src/main/resources/template/bootstrap/checkbox.ftl
@@ -19,18 +19,15 @@
  */
 -->
 <#assign hasFieldErrors = fieldErrors?? && fieldErrors[parameters.name]??/>
-<#if hasFieldErrors>
-    <#list fieldErrors[parameters.name] as error>
-    <span class="errorMessage">${error?html}</span><#t/>
-    </#list>
-</#if>
-<div class="form-group<#rt/>
-<#if hasFieldErrors> 
- has-error has-feedback<#rt/>
-</#if>
-${parameters.cssClass?default('')?html}"><#rt/>
-<#if parameters.cssStyle??> style="${parameters.cssStyle?html}"<#rt/>
-</#if>
+<div class="form-group <#t/>
+    <#if hasFieldErrors> 
+        has-error has-feedback <#t/>
+    </#if>
+    ${parameters.cssClass?default('')?html}" <#t/>
+    <#if parameters.cssStyle??>
+        style="${parameters.cssStyle?html}" <#t/>
+    </#if>
+>
     <div class="<@s.property value="#s2b_form_label_class" />"></div>
     <div class="<@s.property value="#s2b_form_element_class" /> controls">
     <#lt/>
@@ -40,26 +37,24 @@ ${parameters.cssClass?default('')?html}"><#rt/>
     <div class="checkbox">
     </#if>
     <#if parameters.label??>
-    <label
+    <label <#rt/>
         <#if parameters.id??>
                 for="${parameters.id?html}" <#t/>
         </#if>
-            ><#t/>
+    ><#lt/>
         <#if parameters.required?default(false) && parameters.requiredposition?default("right") != 'right'>
-            <span class="required">*</span><#t/>
+            <span class="required">*</span><#rt/>
         </#if>
         <#include "/${parameters.templateDir}/bootstrap/simple/checkbox.ftl" />
-    ${parameters.label?html}<#t/>
+        ${parameters.label?html}<#t/>
         <#if parameters.required?default(false) && parameters.requiredposition?default("right") == 'right'>
             <span class="required">*</span><#t/>
         </#if>
-    ${parameters.labelseparator?default("")?html}<#t/>
+        ${parameters.labelseparator?default("")?html}<#t/>
         <#include "/${parameters.templateDir}/bootstrap/tooltip.ftl" />
-
     </#if>
-
     <#if parameters.label??>
-    </label><#t/>
+    </label>
     </div><#t/>
     </#if>
     <#include "/${parameters.templateDir}/bootstrap/controlfooter.ftl" /><#nt/>

--- a/struts2-bootstrap-plugin/src/main/resources/template/bootstrap/checkboxlist.ftl
+++ b/struts2-bootstrap-plugin/src/main/resources/template/bootstrap/checkboxlist.ftl
@@ -19,33 +19,28 @@
  */
 -->
 <#assign hasFieldErrors = fieldErrors?? && fieldErrors[parameters.name]??/>
-<#if hasFieldErrors>
-    <#list fieldErrors[parameters.name] as error>
-    <span class="errorMessage">${error?html}</span><#t/>
-    </#list>
-</#if>
 <div class="form-group <#rt/>
-<#if hasFieldErrors>
- has-error has-feedback<#rt/>
-</#if>
- ${parameters.cssClass?default('')?html}"><#rt/>
-<#if parameters.cssStyle??> style="${parameters.cssStyle?html}"<#rt/>
-</#if>
-<#if parameters.label??>
-    <label class="<@s.property value="#s2b_form_label_class" /> control-label" <#t/>
-            ><#t/>
-        <#if parameters.required?default(false) && parameters.requiredposition?default("right") != 'right'>
-            <span class="required">*</span><#t/>
-        </#if>
-    ${parameters.label?html}<#t/>
-        <#if parameters.required?default(false) && parameters.requiredposition?default("right") == 'right'>
-            <span class="required">*</span><#t/>
-        </#if>
-    ${parameters.labelseparator?default("")?html}<#rt/>
-        <#include "/${parameters.templateDir}/bootstrap/tooltip.ftl" />
-    </label><#rt/>
-</#if>
+    <#if hasFieldErrors>
+        has-error has-feedback<#t/>
+    </#if>
+    ${parameters.cssClass?default('')?html}" <#t/>
+    <#if parameters.cssStyle??>
+        style="${parameters.cssStyle?html}" <#t/>
+    </#if>
+>
+    <#if parameters.label??>
+        <label class="<@s.property value="#s2b_form_label_class" /> control-label" >
+            <#if parameters.required?default(false) && parameters.requiredposition?default("right") != 'right'>
+                <span class="required">*</span><#rt/>
+            </#if>
+            ${parameters.label?html}<#rt/>
+            <#if parameters.required?default(false) && parameters.requiredposition?default("right") == 'right'>
+                <span class="required">*</span> <#rt/>
+            </#if>
+            ${parameters.labelseparator?default("")?html}<#t/>
+            <#include "/${parameters.templateDir}/bootstrap/tooltip.ftl" /><#lt/>
+        </label>
+    </#if>
     <div class="<@s.property value="#s2b_form_element_class" /> controls">
-    <#lt/>
 <#include "/${parameters.templateDir}/bootstrap/simple/checkboxlist.ftl" />
 <#include "/${parameters.templateDir}/bootstrap/controlfooter.ftl" /><#nt/>

--- a/struts2-bootstrap-plugin/src/main/resources/template/bootstrap/radiomap.ftl
+++ b/struts2-bootstrap-plugin/src/main/resources/template/bootstrap/radiomap.ftl
@@ -19,12 +19,6 @@
  */
 -->
 <#assign hasFieldErrors = fieldErrors?? && fieldErrors[parameters.name]??/>
-<#if hasFieldErrors>
-    <#list fieldErrors[parameters.name] as error>
-    <span class="errorMessage">${error?html}</span><#t/>
-    </#list>
-</#if>
-
 <#if (parameters.dynamicAttributes?? && parameters.dynamicAttributes?size > 0 && parameters.dynamicAttributes["labelCssClass"]??)><#rt/>
     <#assign labelCssClass = parameters.dynamicAttributes.remove("labelCssClass")/><#rt/>
 <#else>
@@ -36,13 +30,15 @@
     <#assign elementCssClass ><@s.property value="#s2b_form_element_class" /></#assign><#rt/>
 </#if><#rt/>
 
-<div class="form-group <#rt/>
-<#if hasFieldErrors>
- has-error has-feedback<#rt/>
-</#if>
- ${parameters.cssClass?default('')?html}"><#rt/>
-<#if parameters.cssStyle??> style="${parameters.cssStyle?html}"<#rt/>
-</#if>
+<div class="form-group <#t/>
+    <#if hasFieldErrors>
+        has-error has-feedback <#t/>
+    </#if>
+    ${parameters.cssClass?default('')?html}" <#t/>
+    <#if parameters.cssStyle??>
+        style="${parameters.cssStyle?html}" <#t/>
+    </#if>
+>
 <#if parameters.label??>
     <label class="${labelCssClass?html} /> control-label">
         <#if parameters.required?default(false) && parameters.requiredposition?default("right") != 'right'>
@@ -54,7 +50,7 @@
         </#if>
     ${parameters.labelseparator?default("")?html}<#t/>
         <#include "/${parameters.templateDir}/bootstrap/tooltip.ftl" />
-    </label><#rt/>
+    </label>
 </#if>
     <div class="${elementCssClass?html} controls">
     <#lt/>

--- a/struts2-bootstrap-plugin/src/main/resources/template/bootstrap/simple/checkbox.ftl
+++ b/struts2-bootstrap-plugin/src/main/resources/template/bootstrap/simple/checkbox.ftl
@@ -20,32 +20,33 @@
  * under the License.
  */
 -->
-<input type="checkbox" name="${parameters.name?html}" value="${parameters.fieldValue?html}"<#rt/>
-<#if parameters.nameValue?? && parameters.nameValue>
-       checked="checked"<#rt/>
-</#if>
-<#if parameters.disabled?default(false)>
-       disabled="disabled"<#rt/>
-</#if>
-<#if parameters.readonly?default(false)>
-       readonly="readonly"<#rt/>
-</#if>
-<#if parameters.tabindex??>
-       tabindex="${parameters.tabindex?html}"<#rt/>
-</#if>
-<#if parameters.id??>
-       id="${parameters.id?html}"<#rt/>
-</#if>
-<#include "/${parameters.templateDir}/simple/css.ftl" />
-<#if parameters.title??>
-       title="${parameters.title?html}"<#rt/>
-</#if>
-<#include "/${parameters.templateDir}/${parameters.expandTheme}/scripting-events.ftl" />
-<#include "/${parameters.templateDir}/${parameters.expandTheme}/common-attributes.ftl" />
-<#include "/${parameters.templateDir}/${parameters.expandTheme}/dynamic-attributes.ftl" />
-        /><input type="hidden" id="__checkbox_${parameters.id?html}" name="__checkbox_${parameters.name?html}"
-                 value="${parameters.fieldValue?html}"<#rt/>
-<#if parameters.disabled?default(false)>
-                 disabled="disabled"<#rt/>
-</#if>
-        />
+<input type="checkbox" name="${parameters.name?html}" value="${parameters.fieldValue?html}" <#rt/>
+    <#if parameters.nameValue?? && parameters.nameValue>
+        checked="checked" <#t/>
+    </#if>
+    <#if parameters.disabled?default(false)>
+        disabled="disabled" <#t/>
+    </#if>
+    <#if parameters.readonly?default(false)>
+        readonly="readonly" <#t/>
+    </#if>
+    <#if parameters.tabindex??>
+        tabindex="${parameters.tabindex?html}" <#t/>
+    </#if>
+    <#if parameters.id??>
+        id="${parameters.id?html}" <#t/>
+    </#if>
+    <#include "/${parameters.templateDir}/simple/css.ftl" />
+    <#if parameters.title??>
+        title="${parameters.title?html}" <#t/>
+    </#if>
+    <#include "/${parameters.templateDir}/${parameters.expandTheme}/scripting-events.ftl" /> <#t/>
+    <#include "/${parameters.templateDir}/${parameters.expandTheme}/common-attributes.ftl" /> <#t/>
+    <#include "/${parameters.templateDir}/${parameters.expandTheme}/dynamic-attributes.ftl" /> <#t/>
+/>
+<input type="hidden" id="__checkbox_${parameters.id?html}" name="__checkbox_${parameters.name?html}" <#rt/>
+    value="${parameters.fieldValue?html}" <#t/>
+    <#if parameters.disabled?default(false)>
+        disabled="disabled"<#rt/>
+    </#if>
+/>

--- a/struts2-bootstrap-plugin/src/main/resources/template/bootstrap/simple/checkboxlist.ftl
+++ b/struts2-bootstrap-plugin/src/main/resources/template/bootstrap/simple/checkboxlist.ftl
@@ -40,23 +40,22 @@
             <div class="checkbox">
         </#if>
         <label for="${parameters.name?html}-${itemCount}" class="${labelClass}">
-
-            <input type="checkbox" name="${parameters.name?html}" value="${itemKeyStr?html}"
-                   id="${parameters.name?html}-${itemCount}"<#rt/>
+            <input type="checkbox" name="${parameters.name?html}" value="${itemKeyStr?html}" <#rt/>
+                   id="${parameters.name?html}-${itemCount}" <#t/>
                 <#if tag.contains(parameters.nameValue, itemKey)>
-                   checked="checked"<#rt/>
+                   checked="checked" <#t/>
                 </#if>
                 <#if parameters.disabled?default(false)>
-                   disabled="disabled"<#rt/>
+                   disabled="disabled" <#t/>
                 </#if>
                 <#if parameters.title??>
-                   title="${parameters.title?html}"<#rt/>
+                   title="${parameters.title?html}" <#t/>
                 </#if>
-                <#include "/${parameters.templateDir}/simple/css.ftl" />
-                <#include "/${parameters.templateDir}/simple/scripting-events.ftl" />
-                <#include "/${parameters.templateDir}/simple/common-attributes.ftl" />
-                    /><#rt/>
-        ${itemValue?html}<#rt/>
+                <#include "/${parameters.templateDir}/simple/css.ftl" /> <#t/>
+                <#include "/${parameters.templateDir}/simple/scripting-events.ftl" /> <#t/>
+                <#include "/${parameters.templateDir}/simple/common-attributes.ftl" /> <#t/>
+            /><#lt/>
+            ${itemValue?html}
         </label>
         <#if parameters.labelposition?default("") != 'inline'>
             </div>

--- a/struts2-bootstrap-plugin/src/main/resources/template/bootstrap/simple/radiomap.ftl
+++ b/struts2-bootstrap-plugin/src/main/resources/template/bootstrap/simple/radiomap.ftl
@@ -33,45 +33,42 @@
         <#assign itemValue = stack.findString('top')/>
     </#if>
     <#if parameters.labelposition?default("") == 'inline'>
-        <#assign labelClass="radio-inline"/>
+        <#assign labelClass="radio-inline"/><#lt/>
     <#else>
         <#assign labelClass=""/>
-        <div class="radio">
+        <div class="radio"><#lt/>
     </#if>
     <label for="${parameters.name?html}-${itemCount}" class="${labelClass}">
-        <input type="radio"<#rt/>
+        <input type="radio" <#rt/>
             <#if parameters.name??>
-               name="${parameters.name?html}"<#rt/>
+               name="${parameters.name?html}" <#t/>
             </#if>
-               id="${parameters.name?html}-${itemCount}"<#rt/>
+               id="${parameters.name?html}-${itemCount}" <#t/>
             <#if tag.contains(parameters.nameValue?default(''), itemKeyStr)>
-               checked="checked"<#rt/>
+               checked="checked" <#t/>
             </#if>
             <#if itemKey??>
-               value="${itemKeyStr?html}"<#rt/>
+               value="${itemKeyStr?html}" <#t/>
             </#if>
             <#if parameters.disabled?default(false)>
-               disabled="disabled"<#rt/>
+               disabled="disabled" <#t/>
             </#if>
             <#if parameters.tabindex??>
-               tabindex="${parameters.tabindex?html}"<#rt/>
-            </#if>
-            <#if parameters.cssClass??>
-               class="${parameters.cssClass?html}"<#rt/>
+               tabindex="${parameters.tabindex?html}" <#t/>
             </#if>
             <#if parameters.cssStyle??>
-               style="${parameters.cssStyle?html}"<#rt/>
+               style="${parameters.cssStyle?html}" <#t/>
             </#if>
-            <#include "/${parameters.templateDir}/simple/css.ftl" />
+            <#include "/${parameters.templateDir}/simple/css.ftl" /> <#t/>
             <#if parameters.title??>
-               title="${parameters.title?html}"<#rt/>
+               title="${parameters.title?html}" <#t/>
             </#if>
             <#include "/${parameters.templateDir}/simple/scripting-events.ftl" />
             <#include "/${parameters.templateDir}/simple/common-attributes.ftl" />
-                /><#rt/>
-    ${itemValue}<#t/>
+        /><#lt/>
+        ${itemValue}
     </label>
     <#if parameters.labelposition?default("") != 'inline'>
-    </div>
+    </div><#lt/>
     </#if>
 </@s.iterator>


### PR DESCRIPTION
issue:
* #19 

Changes:
* removed duplicate field error
* made cssStyle attribute to be renedered correctly (as the style attribute)
* prevented class attribute to be rendered twice on the same HTML-element
* changed indentation
* changed amount of whitespace generated

@jogep Can you verify this pull request for the following reasons:
* I'm not used to working with Freemarker Templates
* I don't know if you agree with the changes in the formatting/whitespace rendering