### PR TITLE
Removes %{..} evaluation in test for activeMenu parameter as not required.

### DIFF
--- a/struts2-bootstrap-showcase/src/main/webapp/WEB-INF/content/includes/menu.jsp
+++ b/struts2-bootstrap-showcase/src/main/webapp/WEB-INF/content/includes/menu.jsp
@@ -6,7 +6,7 @@
   <ul class="nav nav-pills flex-column mb-auto">
     <li class="nav-item">
       <s:url var="index_url" action="index"/>
-      <s:if test='%{#attr.activeMenu == "index"}'>
+      <s:if test='#attr.activeMenu == "index"'>
         <s:a href="%{index_url}" cssClass="nav-link active"><i class="bi bi-grid"></i> Horizontal Form Layout</s:a>
       </s:if>
       <s:else>
@@ -15,7 +15,7 @@
     </li>
     <li class="nav-item">
       <s:url var="vertical_url" action="vertical"/>
-      <s:if test='%{#attr.activeMenu == "vertical"}'>
+      <s:if test='#attr.activeMenu == "vertical"'>
         <s:a href="%{vertical_url}" cssClass="nav-link active"><i class="bi bi-list-task"></i> Vertical Form Layout</s:a>
       </s:if>
       <s:else>
@@ -24,7 +24,7 @@
     </li>
     <li class="nav-item">
       <s:url var="validation_url" action="validation"/>
-      <s:if test='%{#attr.activeMenu == "validation"}'>
+      <s:if test='#attr.activeMenu == "validation"'>
         <s:a href="%{validation_url}" cssClass="nav-link active"><i class="bi bi-exclamation-diamond-fill"></i> Client Side Validation</s:a>
       </s:if>
       <s:else>
@@ -33,7 +33,7 @@
     </li>
     <li class="nav-item">
       <s:url var="advanced_url" action="advanced"/>
-      <s:if test='%{#attr.activeMenu == "advanced"}'>
+      <s:if test='#attr.activeMenu == "advanced"'>
         <s:a href="%{advanced_url}" cssClass="nav-link active"><i class="bi bi-easel2-fill"></i> Advanced Examples</s:a>
       </s:if>
       <s:else>
@@ -42,7 +42,7 @@
     </li>
     <li class="nav-item">
       <s:url var="jquery_url" action="jquery"/>
-      <s:if test='%{#attr.activeMenu == "jquery"}'>
+      <s:if test='#attr.activeMenu == "jquery"'>
         <s:a href="%{jquery_url}" cssClass="nav-link active"><i class="bi bi-capsule-pill"></i> Struts2 jQuery UI Examples</s:a>
       </s:if>
       <s:else>
@@ -51,7 +51,7 @@
     </li>
     <li class="nav-item">
       <s:url var="custom_url" action="custom"/>
-      <s:if test='%{#attr.activeMenu == "custom"}'>
+      <s:if test='#attr.activeMenu == "custom"'>
         <s:a href="%{custom_url}" cssClass="nav-link active"><i class="bi bi-boxes"></i> With Custom Theme</s:a>
       </s:if>
       <s:else>
@@ -60,7 +60,7 @@
     </li>
     <li class="nav-item">
       <s:url var="customlayout_url" action="customlayout"/>
-      <s:if test='%{#attr.activeMenu == "customlayout"}'>
+      <s:if test='#attr.activeMenu == "customlayout"'>
         <s:a href="%{customlayout_url}" cssClass="nav-link active"><i class="bi bi-layout-three-columns"></i> Multi Column Forms</s:a>
       </s:if>
       <s:else>

--- a/struts2-bootstrap-showcase/src/main/webapp/WEB-INF/content/includes/topMenu.jsp
+++ b/struts2-bootstrap-showcase/src/main/webapp/WEB-INF/content/includes/topMenu.jsp
@@ -13,7 +13,7 @@
       <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
         <li>
           <s:url var="index_url" action="index"/>
-          <s:if test='%{#attr.activeMenu == "home"}'>
+          <s:if test='#attr.activeMenu == "home"'>
             <s:a href="%{index_url}" cssClass="nav-link px-2 text-secondary" aria-current="page"><i class="bi bi-house"></i> Home</s:a>
           </s:if>
           <s:else>
@@ -22,7 +22,7 @@
         </li>
         <li>
           <s:url var="about_url" action="about"/>
-          <s:if test='%{#attr.activeMenu == "about"}'>
+          <s:if test='#attr.activeMenu == "about"'>
             <s:a href="%{about_url}" cssClass="nav-link px-2 text-secondary" aria-current="page"><i class="bi bi-postcard"></i> About</s:a>
           </s:if>
           <s:else>


### PR DESCRIPTION
Missed this when removing jstl.  Dont need the %{,,} in the test

<s:if test='#attr.activeMenu == "index"'>
</s:if>