### PR TITLE
ci: prevent CI from deploying release versions unsigned

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,5 +37,11 @@ jobs:
     - name: Deploy SNAPSHOT
       if: github.ref == 'refs/heads/release/6.0.x' || github.ref == 'refs/heads/release/5.0.x'
       run: |
+        VERSION=$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)
+        if [[ "$VERSION" != *-SNAPSHOT ]]; then
+          echo "⏭️  Version $VERSION is not a SNAPSHOT (release-plugin commit) — skipping deploy"
+          exit 0
+        fi
+        echo "🚀 Deploying $VERSION"
         echo "${{ secrets.MAVEN_SETTINGS }}" > ~/.m2/settings-central.xml
         mvn -B -DskipTests=true deploy -s ~/.m2/settings-central.xml

--- a/struts2-bootstrap-showcase/pom.xml
+++ b/struts2-bootstrap-showcase/pom.xml
@@ -29,6 +29,13 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <skipPublishing>true</skipPublishing>
+                </configuration>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
## Problem

Releasing `6.1.0` failed publishing to the Central Portal with `Missing signature for file` for every artifact ([run 28497025088](https://github.com/struts-community-plugins/struts2-bootstrap/actions/runs/28497025088)).

Root cause: the **Deploy SNAPSHOT** job runs `mvn deploy` without `-Prelease` (no GPG signing) on every push to `release/6.0.x`. When `mvn release:prepare` pushes its `[maven-release-plugin] prepare release 6.1.0` commit, the POM version is briefly the *release* version `6.1.0`, so CI uploaded an **unsigned** `6.1.0` bundle to the Portal — and that unsigned deployment, not the signed one from `release:perform`, is what failed validation.

## Fix

- **`maven.yml`**: the deploy step now reads `project.version` and skips unless it ends in `-SNAPSHOT`, so a release-plugin commit can never trigger a release deploy.
- **`struts2-bootstrap-showcase/pom.xml`**: add `<skipPublishing>true</skipPublishing>` to `central-publishing-maven-plugin` so the demo war is not published to Maven Central.

Same approach as struts2-jquery#923, adapted to this repo (no `skipITs`/integration-tests module here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)