### PR TITLE
docs: require Struts 7.3.0 for struts2-bootstrap 6.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@
 
 A Plugin for simple Bootstrap CSS Framework integration into Struts2.
 
-### [Download] (https://repo1.maven.org/maven2/com/jgeppert/struts2/bootstrap/)
-### [News and Developer Blog] (https://www.jgeppert.com)
-### [Showcase] (https://struts.jgeppert.com/struts2-bootstrap-showcase/)
-### [Sample TODO app based on Bootstrap, jQuery and jQuery Mobile] (https://github.com/jogep/struts2-todo-examples/)
+## Links
+
+- [Download](https://repo1.maven.org/maven2/com/jgeppert/struts2/bootstrap/) - releases on Maven Central
+- [Showcase](https://struts.jgeppert.com/struts2-bootstrap-showcase/) - live demo of the plugin
+- [News and Developer Blog](https://www.jgeppert.com)
+- [Sample TODO app](https://github.com/jogep/struts2-todo-examples/) - based on Bootstrap, jQuery and jQuery Mobile
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,17 @@ Copy the struts2-bootstrap-plugin.jar into your WEB-INF/lib path.
 ### Versions and compatibility
 | `struts2-bootstrap` version | `struts2` version  | `Java` version |
 |-----------------------------|--------------------|----------------|
+| `6.2.0`                     | version >= `7.3.0` | Java 17        |
 | `6.1.1`                     | version >= `7.2.2` | Java 17        |
 | `6.0.0`                     | version >= `7.0.0` | Java 17        |
 | `5.0.6`                     | version >= `6.7.0` | Java 8         |
 | `5.0.5`                     | version >= `6.6.0` | Java 7         |
 | `5.0.2`                     | version >= `6.1`   | Java 7         |
 | `5.0.0`                     | version >= `6.0`   | Java 7         |
+
+Starting with `6.2.0` the plugin no longer bundles Bootstrap and Bootstrap Icons. The assets are
+pulled in as [WebJars](https://www.webjars.org/) and served by Struts' built-in WebJars support,
+which is why Struts `7.3.0` or newer is required.
 
 ### Maven
 
@@ -32,7 +37,7 @@ Copy the struts2-bootstrap-plugin.jar into your WEB-INF/lib path.
     <dependency>
         <groupId>com.jgeppert.struts2.bootstrap</groupId>
         <artifactId>struts2-bootstrap-plugin</artifactId>
-        <version>6.1.1</version>
+        <version>6.2.0</version>
     </dependency>
     ...
 </dependencies>


### PR DESCRIPTION
## Summary

`6.2.0` is released, but the README still documented `6.1.1` as the newest version and did not state the new Struts baseline. Since #423 the plugin serves Bootstrap and Bootstrap Icons through Struts' WebJars support instead of bundling the dist files, and the build targets Struts `7.3.0`.

- adds a `6.2.0` row to the compatibility table with `struts2` version `>= 7.3.0`
- notes why the higher baseline is needed (WebJars-served assets, no bundled dist files)
- bumps the Maven snippet from `6.1.1` to `6.2.0`
- fixes the top-of-file links (Download / Showcase / Blog / TODO sample): they used `[text] (url)` with a space so markdown never rendered them as links, and were `###` headings; they now live under a `## Links` section as a list. All four URLs were checked and still resolve.

## Notes

Unrelated and left alone: the "Using SNAPSHOT builds" section still points at `http://oss.sonatype.org/content/repositories/snapshots`, which is retired — worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)